### PR TITLE
bugfix: double close on file output write error

### DIFF
--- a/dnstap_fstrm_file_output.go
+++ b/dnstap_fstrm_file_output.go
@@ -84,7 +84,6 @@ func (o *DnstapFstrmFileOutput) open() error {
 
 func (o *DnstapFstrmFileOutput) write(frame []byte) error {
 	if _, err := o.enc.Write(frame); err != nil {
-		o.close()
 		return err
 	}
 	return nil


### PR DESCRIPTION
If there is an error on a file write, a double close operation is performed, generating the following panic:

```
panic: close of closed channel

goroutine 9 [running]:
gitlab.com/pert/dtap-teco.(*DnstapFstrmFileOutput).close(0xc00020a340)
        /home/x300092/go/src/gitlab.com/pert/dtap-teco/dnstap_fstrm_file_output.go:97 +0x5e
gitlab.com/pert/dtap-teco.(*DnstapOutput).Run(0xc00000ed50, {0xc8a470, 0xc00020a3c0})
        /home/x300092/go/src/gitlab.com/pert/dtap-teco/dnstap_output.go:62 +0x1c5
main.main.func1({0xc83670, 0xc00000ed50})
        /home/x300092/go/src/gitlab.com/pert/dtap-teco/cmd/dtap-teco/main.go:225 +0x3b
created by main.main
        /home/x300092/go/src/gitlab.com/pert/dtap-teco/cmd/dtap-teco/main.go:224 +0x2be8
```